### PR TITLE
chore: Remove the commit message prefix for Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,8 +3,6 @@ version: 2
 updates:
   - package-ecosystem: "terraform"
     directory: "/"
-    commit-message:
-      prefix: "chore"
     schedule:
       interval: "daily"
       time: "07:00"
@@ -12,8 +10,6 @@ updates:
 
   - package-ecosystem: "github-actions"
     directory: "/"
-    commit-message:
-      prefix: "chore"
     schedule:
       interval: "daily"
       time: "07:00"
@@ -21,8 +17,6 @@ updates:
 
   - package-ecosystem: "pip"
     directory: "/"
-    commit-message:
-      prefix: "chore"
     schedule:
       interval: "daily"
       time: "07:00"


### PR DESCRIPTION
**Description**
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Removing the commit message prefix for Dependabot to fall back to normal conventional commit messages provided by Dependabot.