### PR TITLE
feat(main): Add configuration for shared_access_key_enabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ module "terraform_state_storage_account" {
   storage_account_table_encryption_key_type                              = "Account"
   storage_account_infrastructure_encryption_enabled                      = true
   storage_account_allow_nested_items_to_be_public                        = true
+  storage_account_shared_access_key_enabled                              = true
   storage_account_queue_properties_logging_delete                        = false
   storage_account_queue_properties_logging_read                          = false
   storage_account_queue_properties_logging_write                         = false

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -17,6 +17,7 @@ module "terraform_state_storage_account" {
   storage_account_table_encryption_key_type                              = "Account"
   storage_account_infrastructure_encryption_enabled                      = true
   storage_account_allow_nested_items_to_be_public                        = true
+  storage_account_shared_access_key_enabled                              = true
   storage_account_queue_properties_logging_delete                        = false
   storage_account_queue_properties_logging_read                          = false
   storage_account_queue_properties_logging_write                         = false

--- a/main.tf
+++ b/main.tf
@@ -12,6 +12,7 @@ resource "azurerm_storage_account" "this" {
   table_encryption_key_type         = var.storage_account_table_encryption_key_type
   infrastructure_encryption_enabled = var.storage_account_infrastructure_encryption_enabled
   allow_nested_items_to_be_public   = var.storage_account_allow_nested_items_to_be_public
+  shared_access_key_enabled         = var.storage_account_shared_access_key_enabled
 
   queue_properties {
     logging {

--- a/variables.tf
+++ b/variables.tf
@@ -68,6 +68,12 @@ variable "storage_account_allow_nested_items_to_be_public" {
   default     = false
 }
 
+variable "storage_account_shared_access_key_enabled" {
+  type        = bool
+  description = "(optional) Indicates whether the storage account permits requests to be authorized with the account access key"
+  default     = false
+}
+
 variable "storage_account_queue_properties_logging_delete" {
   type        = bool
   description = "(optional) Indicates whether all delete requests should be logged"


### PR DESCRIPTION
**Description**

The configuration `shared_access_key_enabled` is added to prevent running into CKV2_AZURE_40.

**References**

https://docs.prismacloud.io/en/enterprise-edition/policy-reference/azure-policies/azure-iam-policies/bc-azure-2-40
