### PR TITLE
fix(documentation): Add a link to Terraform backend configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,9 @@ terraform {
 }
 ```
 
+For a detailed look into available options, see the
+[available configuration options](https://developer.hashicorp.com/terraform/language/settings/backends/azurerm).
+
 #### Terraform provider configuration
 
 To let the Terraform provider access the storage account without a shared access key, the following


### PR DESCRIPTION
**Description**

Add a link to the HashiCorp documentation for the azurerm backend configuration.