### PR TITLE
fix(main): Update required azurerm version to 3.114.0

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">= 3.0"
+      version = ">= 3.114.0"
     }
   }
 }


### PR DESCRIPTION
**Description**

Update the required azurerm provider version to 3.114.0 as the underlying configuration for storage_account_https_traffic_only_enabled did not exist before.