### PR TITLE
chore(main): Disable Markdown Prettifier

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -38,4 +38,5 @@ jobs:
           VALIDATE_TERRAFORM_TERRASCAN: false
           VALIDATE_CHECKOV: false
           VALIDATE_JSCPD: false
+          VALIDATE_MARKDOWN_PRETTIER: false
           VALIDATE_NATURAL_LANGUAGE: false


### PR DESCRIPTION
**Description**

Disable the Markdown Prettifier in super-linter to avoid complaints about automatically generated changelog.