### PR TITLE
feat: Add role assignments for Storage Account and Key Vault

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,24 @@ assigned. Please note that having the `Owner` or `Contributor` role assigned is 
 the user prinicipal needs one of the `Storage Blob Data xxx` roles to access data within the
 storage blob.
 
+Permissions can also directly assigned via the `storage_account_role_assignments` variable (or the respective
+`key_vault_role_assignments` variable for the Key Vault), similar to the following example
+
+```terraform
+...
+data_disks = {
+  user_1 = {
+    principal_id         = "123"
+    role_definition_name = "Storage Blob Data Contributor"
+  }
+  user_2 = {
+    principal_id         = "456"
+    role_definition_name = "Storage Blob Data Contributor"
+  }
+}
+...
+```
+
 #### Storage Container configuration
 
 With the use of `storage_account_shared_access_key_enabled` the authentication method for the

--- a/main.tf
+++ b/main.tf
@@ -61,6 +61,14 @@ resource "azurerm_storage_container" "this" {
   container_access_type = var.storage_container_container_access_type
 }
 
+resource "azurerm_role_assignment" "this_storage_account" {
+  for_each = var.storage_account_role_assignments
+
+  principal_id         = each.value.principal_id
+  role_definition_name = each.value.role_definition_name
+  scope                = azurerm_storage_account.this.id
+}
+
 resource "azurerm_key_vault" "this" {
   name                      = var.key_vault_name
   resource_group_name       = var.storage_account_resource_group_name
@@ -84,4 +92,16 @@ resource "azurerm_key_vault_key" "this" {
   expiration_date = var.key_vault_key_expiration_date
 
   tags = var.tags
+
+  depends_on = [
+    azurerm_role_assignment.this_key_vault,
+  ]
+}
+
+resource "azurerm_role_assignment" "this_key_vault" {
+  for_each = var.key_vault_role_assignments
+
+  principal_id         = each.value.principal_id
+  role_definition_name = each.value.role_definition_name
+  scope                = azurerm_key_vault.this.id
 }

--- a/variables.tf
+++ b/variables.tf
@@ -170,6 +170,15 @@ variable "storage_account_blob_properties_delete_retention_policy_days" {
   default     = 7
 }
 
+variable "storage_account_role_assignments" {
+  type = map(object({
+    principal_id         = string
+    role_definition_name = string
+  }))
+  description = "(optional) A map of role assignments to be created for the storage account"
+  default     = {}
+}
+
 # azurerm_storage_container variables
 variable "storage_container_name" {
   type        = string
@@ -239,4 +248,13 @@ variable "key_vault_key_key_opts" {
 variable "key_vault_key_expiration_date" {
   type        = string
   description = "Expiration UTC datetime of the key vault key"
+}
+
+variable "key_vault_role_assignments" {
+  type = map(object({
+    principal_id         = string
+    role_definition_name = string
+  }))
+  description = "(optional) A map of role assignments to be created for the key vault"
+  default     = {}
 }


### PR DESCRIPTION
**Description**

Add `storage_account_role_assignments` and `key_vault_role_assignments` variables to enable setting permissions directly in the module.